### PR TITLE
Update pws-scdf-setup.sh

### DIFF
--- a/pws-scdf-setup.sh
+++ b/pws-scdf-setup.sh
@@ -106,7 +106,7 @@ echo "Setting the environmental variables. The following will be ran:"
 
 echo ""
 cf set-env $ADMIN MAVEN_REMOTE_REPOSITORIES_REPO1_URL https://repo.spring.io/libs-snapshot
-cf set-env ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_URL https://api.run.pivotal.io
+cf set-env $ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_URL https://api.run.pivotal.io
 cf set-env $ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN cfapps.io
 cf set-env $ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES $RABBIT
 cf set-env $ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SERVICES $REDIS,$RABBIT


### PR DESCRIPTION
Cloud Foundry URL was not being set due to a missing $ before the ADMIN Causing the service to Crash on startup.
cf set-env ADMIN SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_URL https://api.run.pivotal.io